### PR TITLE
Fix unintended Int to Long cast in VarHandle call

### DIFF
--- a/src/main/scala/example/ActorCell.scala
+++ b/src/main/scala/example/ActorCell.scala
@@ -19,7 +19,7 @@ class ActorCell {
   }
 
   def nextNameHandle: Long = {
-    AbstractActorCell.nextNameHandle.getAndAdd(this, 1).asInstanceOf[Long]
+    AbstractActorCell.nextNameHandle.getAndAdd(this, 1L)
   }
 
   def nextNameAtomic: Long = {


### PR DESCRIPTION
The underlying reason why the `getAndAdd` call was slow is because `1` was being passed in as `Int` and since the method signature of `getAndAdd` is as follows

```java
Object getAndAdd(Object... args);
```

The int was being cast to a `Long`, making it slower. Using `1L` enforces that a Long primitive literal is being passed, removing the redundant cast.

The `asInstanceOf[Long]` was also removed since its pointless.

This is the result after the change

```
[info] Benchmark                      Mode  Cnt           Score           Error  Units
[info] AsciiBytesBench.getBytes      thrpt    3    37922208.366 ±   1485363.384  ops/s
[info] AsciiBytesBench.unsafe        thrpt    3   155413560.186 ±   7557873.145  ops/s
[info] GetAndAddBench.atomic         thrpt    3  2798977574.004 ±  34151068.600  ops/s
[info] GetAndAddBench.atomicUpdater  thrpt    3  2762483163.270 ±  23717488.387  ops/s
[info] GetAndAddBench.handle         thrpt    3  2802234492.793 ±  75023428.867  ops/s
[info] GetAndAddBench.unsafe         thrpt    3  2800961765.678 ± 134231191.366  ops/s
[info] GetMapBench.atomic            thrpt    3  7068978860.652 ± 752771741.136  ops/s
[info] GetMapBench.unsafe            thrpt    3  7805819042.523 ± 104793534.198  ops/s
```

Its just as fast as the unsafe version while being slightly faster than atomic/atomicUpdater